### PR TITLE
compatible for browser environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var origSymbol = global.Symbol;
+var origSymbol = typeof global !== 'undefined' ? global.Symbol
+	: typeof window !== 'undefined' ? window.Symbol : undefined;
+
 var hasSymbolSham = require('./shams');
 
 module.exports = function hasNativeSymbols() {


### PR DESCRIPTION
**Background**
**has-symbols** is widely referenced in both node and browser environment, weeks ago got below error in browser's console:

> ReferenceError: global is not defined


So the PR is to add type defense for browser environment.