### PR TITLE
fallback to `self` if `global` is unavailable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var origSymbol = global.Symbol;
+var origSymbol = (global || self).Symbol;
 var hasSymbolSham = require('./shams');
 
 module.exports = function hasNativeSymbols() {


### PR DESCRIPTION
This situation occurs when using a bundler such as Parcel which does not add `global` when bundling for a web-app